### PR TITLE
Add semi-colon for crypto_sign_ed25519_*BYTES

### DIFF
--- a/Sodium.xs
+++ b/Sodium.xs
@@ -146,14 +146,14 @@ crypto_sign_SECRETKEYBYTES()
 SV *
 crypto_sign_ed25519_PUBLICKEYBYTES()
     CODE:
-        RETVAL = newSVuv((unsigned int) crypto_sign_ed25519_PUBLICKEYBYTES)
+        RETVAL = newSVuv((unsigned int) crypto_sign_ed25519_PUBLICKEYBYTES);
     OUTPUT:
         RETVAL
         
 SV *
 crypto_sign_ed25519_SECRETKEYBYTES()
     CODE:
-        RETVAL = newSVuv((unsigned int) crypto_sign_ed25519_SECRETKEYBYTES)
+        RETVAL = newSVuv((unsigned int) crypto_sign_ed25519_SECRETKEYBYTES);
     OUTPUT:
         RETVAL
 


### PR DESCRIPTION
crypto_sign_ed25519_PUBLICKEYBYTES() and crypto_sign_ed25519_SECRETKEYBYTES() were missing line terminators (semi-colons). Happens to the best of us ;)  